### PR TITLE
[#24] 오버레이창이 축소, 잘려서 표시되는 문제 수정

### DIFF
--- a/src/components/items/stationItem/index.tsx
+++ b/src/components/items/stationItem/index.tsx
@@ -26,7 +26,7 @@ export const StationItem = ({ type, style, item, onClick }: StationItemProps) =>
     <HStack
       style={style}
       boxSizing="border-box"
-      p="0.5rem"
+      p="6px 18px 4px 15px"
       cursor="pointer"
       gap={0}
       w="100%"
@@ -35,7 +35,7 @@ export const StationItem = ({ type, style, item, onClick }: StationItemProps) =>
     >
       {isBookmark && <BookmarkButton onClick={handleBookmarkClick} isSavedBookmark />}
       <Box ml="0.5rem">
-        <Text fontSize="20px" fontWeight="bold">
+        <Text fontSize="18px" fontWeight="bold" wordBreak="keep-all">
           {item.stationName}
         </Text>
         <Text fontSize="14px" color="grey">

--- a/src/components/main/index.tsx
+++ b/src/components/main/index.tsx
@@ -17,7 +17,7 @@ export const Main = () => {
   };
 
   return (
-    <Stack backgroundColor="white" w="100%" h="100%">
+    <Stack backgroundColor="white" w="100%" h="100%" position="relative">
       <Flex bgColor="#ff9900" p="20px">
         <Link href="/">
           <Box bgColor="#e3e3e3" minW="40px" p="8px" borderRadius="lg" mr="8px">
@@ -28,11 +28,11 @@ export const Main = () => {
           <SearchBox />
         </Box>
       </Flex>
-      <Box p="0 0.5rem">
-        <Heading as="h1" size="md">
+      <Box p="0 1rem">
+        <Heading as="h1" size="md" lineHeight={2}>
           즐겨찾는 정류장
         </Heading>
-        <Box minH="120px" border="1px solid gray" borderRadius="5px">
+        <Box minH="120px" border="1px solid #a8a8a8" borderRadius="10px">
           {bookmarks.length > 0 ? (
             <List>
               {bookmarks.map((bookmark) => (
@@ -49,7 +49,7 @@ export const Main = () => {
           )}
         </Box>
       </Box>
-      <Box p="8px">
+      <Box position="absolute" bottom="1rem" ml="1rem" fontSize="14px" color="#808080">
         <Text>혼잡도 판단기준은 다음과 같습니다.</Text>
         <Text>판단기준(승강장면적, 사람수)</Text>
         <Text>

--- a/src/components/map/MapMarkerContainer.tsx
+++ b/src/components/map/MapMarkerContainer.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
-import { MapMarker, MapMarkerProps, useMap } from 'react-kakao-maps-sdk';
+import { CustomOverlayMap, CustomOverlayMapProps, MapMarker, useMap } from 'react-kakao-maps-sdk';
 import { StationCard } from '@/components/map/StationCard';
 import { useOutsideClick } from '@/hooks/useOutsideClick';
 import { useStationStore } from '@/stores/useStationStore';
 
 interface MapMarkerContainerProps {
-  position: MapMarkerProps['position'];
+  position: CustomOverlayMapProps['position'];
   arsId: string;
 }
 
@@ -32,8 +32,13 @@ export const MapMarkerContainer = ({ position, arsId }: MapMarkerContainerProps)
   };
 
   return (
-    <MapMarker position={position} onClick={handleMarkerClick}>
-      {isOpen && <StationCard ref={ref} arsId={arsId} onClick={() => setIsOpen(false)} />}
-    </MapMarker>
+    <>
+      <MapMarker position={position} onClick={handleMarkerClick} />
+      {isOpen && (
+        <CustomOverlayMap xAnchor={0} yAnchor={0} position={position}>
+          <StationCard ref={ref} arsId={arsId} onClick={() => setIsOpen(false)} />
+        </CustomOverlayMap>
+      )}
+    </>
   );
 };

--- a/src/components/map/StationCard.tsx
+++ b/src/components/map/StationCard.tsx
@@ -43,7 +43,15 @@ export const StationCard = forwardRef<HTMLDivElement | null, StationCardProps>((
   return (
     !isLoading &&
     isSuccess && (
-      <Box maxH="496px" position="relative" ref={ref} backgroundColor="#fff">
+      <Box
+        position="relative"
+        w="240px"
+        maxH="calc(-4px + 50vh)"
+        transform="translateX(-50%)"
+        ref={ref}
+        backgroundColor="#fff"
+        boxShadow="lg"
+      >
         <CloseButton style={{ position: 'absolute', top: '0.5rem', right: '0.5rem' }} onClick={onClick} />
         <Box p={3} backgroundColor="#eaeaea" minH={1} textAlign="center">
           <Text color="#616161" fontSize="sm">
@@ -59,17 +67,23 @@ export const StationCard = forwardRef<HTMLDivElement | null, StationCardProps>((
             {STATUS_KR[data.result.station.crowding]}
           </Text>
         </Box>
-        <Flex justifyContent="space-between" alignItems="center" border="solid 1px #eaeaea">
-          <Text align="left" fontWeight="bold" fontSize="md" lineHeight={2}>
+        <Flex
+          justifyContent="space-between"
+          alignItems="center"
+          border="solid 1px #eaeaea"
+          paddingLeft={1}
+          paddingRight={1}
+        >
+          <Text align="left" fontWeight="bold" fontSize="sm" lineHeight={2}>
             실시간 버스 정보
           </Text>
-          <Flex>
+          <Flex alignItems="center">
             {isFetching ? (
-              <Text fontSize="sm" color="#929292">
+              <Text fontSize="sm" color="#929292" marginRight={1}>
                 데이터 갱신중..
               </Text>
             ) : (
-              <Text fontSize="sm" color="#929292">
+              <Text fontSize="sm" color="#929292" marginRight={1}>
                 {currentTime}
               </Text>
             )}
@@ -82,7 +96,7 @@ export const StationCard = forwardRef<HTMLDivElement | null, StationCardProps>((
             onClick={handleBookmarkClick}
             isSavedBookmark={isSavedbookmark}
           />
-          <Box maxH="300px" overflowY="auto">
+          <Box maxH="230px" overflowY="auto">
             {data.result.busList.map((bus) => (
               <BusItem key={bus.busId} item={bus} />
             ))}

--- a/src/components/map/StationCard.tsx
+++ b/src/components/map/StationCard.tsx
@@ -1,9 +1,8 @@
 import { forwardRef, useState } from 'react';
-import { Box, Flex, Text } from '@chakra-ui/react';
+import { Badge, Box, Flex, Text, VStack } from '@chakra-ui/react';
 import { STATUS_COLOR, STATUS_KR } from '@/constants/status';
 import { useBookmarksStore } from '@/stores/useBookmarkStore';
-import { getCurrentTime } from '@/lib/utils';
-import { BusItem } from '@/components/items/busItem';
+import { convertSecToMinText, getCurrentTime } from '@/lib/utils';
 import { BookmarkButton } from '@/components/common/buttons/bookmark';
 import { CloseButton } from '@/components/common/buttons/close';
 import { RefreshButton } from '@/components/common/buttons/refresh';
@@ -90,7 +89,38 @@ export const StationCard = forwardRef<HTMLDivElement | null, StationCardProps>((
           />
           <Box maxH="230px" overflowY="auto">
             {data.result.busList.map((bus) => (
-              <BusItem key={bus.busId} item={bus} />
+              <Flex
+                key={bus.busId}
+                alignItems="center"
+                justifyContent="space-between"
+                boxSizing="border-box"
+                p="0.5rem"
+                h="100%"
+                w="100%"
+              >
+                <Box w="30%" whiteSpace="wrap" flex={1}>
+                  <Text fontSize="lg" fontWeight="bold">
+                    {bus.busName}
+                  </Text>
+                  <Text fontSize="sm" color="grey">
+                    {bus.direction}방향
+                  </Text>
+                </Box>
+                <Flex alignItems="center" justifyContent="space-between" lineHeight="1.0rem" gap="1">
+                  <VStack alignItems="flex-end" justifyContent="center" minW="50px">
+                    <Text fontSize="md">{convertSecToMinText(bus.firstArrivalBusTime)}</Text>
+                    <Text fontSize="md">{convertSecToMinText(bus.secondArrivalBusTime)}</Text>
+                  </VStack>
+                  <VStack alignItems="flex-end" justifyContent="center">
+                    <Badge colorScheme={STATUS_COLOR[bus.firstArrivalBusCrowding]}>
+                      {STATUS_KR[bus.firstArrivalBusCrowding]}
+                    </Badge>
+                    <Badge colorScheme={STATUS_COLOR[bus.secondArrivalBusCrowding]}>
+                      {STATUS_KR[bus.secondArrivalBusCrowding]}
+                    </Badge>
+                  </VStack>
+                </Flex>
+              </Flex>
             ))}
           </Box>
         </Box>

--- a/src/components/map/StationCard.tsx
+++ b/src/components/map/StationCard.tsx
@@ -43,15 +43,7 @@ export const StationCard = forwardRef<HTMLDivElement | null, StationCardProps>((
   return (
     !isLoading &&
     isSuccess && (
-      <Box
-        position="relative"
-        w="240px"
-        maxH="calc(-4px + 50vh)"
-        transform="translateX(-50%)"
-        ref={ref}
-        backgroundColor="#fff"
-        boxShadow="lg"
-      >
+      <Box position="relative" w="240px" transform="translateX(-50%)" ref={ref} backgroundColor="#fff" boxShadow="lg">
         <CloseButton style={{ position: 'absolute', top: '0.5rem', right: '0.5rem' }} onClick={onClick} />
         <Box p={3} backgroundColor="#eaeaea" minH={1} textAlign="center">
           <Text color="#616161" fontSize="sm">

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -59,7 +59,7 @@ export const MapContainer = () => {
   }, [data]);
 
   return (
-    <Box h="calc(-56px + 100vh)" w="100%" overflow="hidden">
+    <Box h="100vh" w="100%" overflow="hidden">
       <Suspense fallback={<p>로딩중..</p>}>
         {location.loaded && stationsNearby && (
           <Map center={coordinates} style={{ position: 'relative', width: '100%', height: '100%' }} level={4} isPanto>


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

오버레이창이 축소, 잘려서 표시되는 이슈를  수정했어요. #24 

## 🧑‍💻 PR 세부 내용

1) 아래의 방법을 참고하여, 컨텐츠의 x축, y축의 위치를 마커 아래로 고정했어요. `xAnchor={0} yAnchor={0}`
https://devtalk.kakao.com/t/customoverlay/91652/6

<img width="305" alt="스크린샷 2024-04-16 23 38 37" src="https://github.com/sydney-choi/transit-watch-front-end/assets/68490447/a04ab6dc-99fd-449a-b667-7013b010b428">

`transform="translateX(-50%)"`를 통해 컨텐츠를 마커 가운데로 오도록 했어요.
<img width="269" alt="스크린샷 2024-04-16 23 43 01" src="https://github.com/sydney-choi/transit-watch-front-end/assets/68490447/6efaf0a0-29ce-473f-9d51-876ccad5378a">


2) 오버레이창의  스타일을 수정했어요
## 📸 스크린샷

위를 참고해주세요!🙂

## 👩🏻‍💻 to reviewer
