### PR TITLE
[#22] 북마크가 팝업창에서 비정상적으로 표시되는 것을 수정

### DIFF
--- a/src/components/map/StationCard.tsx
+++ b/src/components/map/StationCard.tsx
@@ -16,21 +16,16 @@ interface StationCardProps {
 
 export const StationCard = forwardRef<HTMLDivElement | null, StationCardProps>(({ arsId, onClick }, ref) => {
   const { bookmarks, addBookmark, deleteBookmark } = useBookmarksStore();
-  const [isSavedbookmark, setIsSavedBookmark] = useState<boolean>(false);
   const [currentTime, setCurrentTime] = useState<string>(getCurrentTime());
   const { data, isLoading, isFetching, refetch, isSuccess } = useGetStationDetail(arsId);
+  const hasBookmark = !!bookmarks.find((target) => target.arsId === arsId);
 
   const handleBookmarkClick = () => {
-    const bookmark = bookmarks.find((target) => target.arsId === arsId);
     // TODO optimistic update로 구현
-    if (bookmark) {
-      setIsSavedBookmark(false);
-      deleteBookmark(bookmark.arsId);
-    } else {
-      setIsSavedBookmark(true);
-      if (data) {
-        addBookmark(data.result.station);
-      }
+    if (hasBookmark) {
+      deleteBookmark(arsId);
+    } else if (data) {
+      addBookmark(data.result.station);
     }
   };
 
@@ -94,7 +89,7 @@ export const StationCard = forwardRef<HTMLDivElement | null, StationCardProps>((
           <BookmarkButton
             style={{ position: 'absolute', top: '-5rem', right: '1rem' }}
             onClick={handleBookmarkClick}
-            isSavedBookmark={isSavedbookmark}
+            isSavedBookmark={hasBookmark}
           />
           <Box maxH="230px" overflowY="auto">
             {data.result.busList.map((bus) => (


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

북마크가 팝업창에서 비정상적으로 표시되는 것을 수정했어요. #22 

## 🧑‍💻 PR 세부 내용

북마크의 상태관리가 zustand와 useState가 별개로 작동하고 있다는 것을 알아냈어요.

북마크 상태관리를 zustand로 통일하고 불필요한 useState를 삭제했어요.

## 📸 스크린샷

<img width="949" alt="스크린샷 2024-04-17 18 21 10" src="https://github.com/sydney-choi/transit-watch-front-end/assets/68490447/b17e2fab-aa40-48ce-bc4d-9c2ab78b88c8">


## 👩🏻‍💻 to reviewer
