### PR TITLE
fix: 파라미터가 0으로 전달되는 것을 수정

### DIFF
--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -17,6 +17,13 @@ export const MapContainer = () => {
   const { station } = useStationStore();
   const [stationsNearby, setStationsNearby] = useState<Station[]>();
   const location = useFindMyLocation();
+  const request: GetStationsNearbyRequest = {
+    xlongitude: coordinates.lng,
+    ylatitude: coordinates.lat,
+    radius: DEFAULT_RADIUS,
+  };
+
+  const { data } = useGetStationsNearby(request);
 
   useEffect(() => {
     // 위치 정보를 허용한 경우
@@ -42,13 +49,6 @@ export const MapContainer = () => {
     }
   }, [location, setCoordinates, station]);
 
-  const request: GetStationsNearbyRequest = {
-    xlongitude: coordinates.lng,
-    ylatitude: coordinates.lat,
-    radius: DEFAULT_RADIUS,
-  };
-  const { data } = useGetStationsNearby(request);
-
   useEffect(() => {
     if (data) {
       setStationsNearby(data.result);
@@ -73,9 +73,9 @@ export const MapContainer = () => {
               />
             )}
             {stationsNearby.map((item) => {
-              const { arsId, xlongitude, ylatitude } = item;
+              const { stationId, arsId, xlongitude, ylatitude } = item;
               return (
-                <MapMarkerContainer key={item.stationId} position={{ lng: xlongitude, lat: ylatitude }} arsId={arsId} />
+                <MapMarkerContainer key={stationId} position={{ lng: xlongitude, lat: ylatitude }} arsId={arsId} />
               );
             })}
             <ResettingMapBounds points={stationsNearby} />

--- a/src/hooks/useGetQueries.tsx
+++ b/src/hooks/useGetQueries.tsx
@@ -30,6 +30,7 @@ export const useGetStationsNearby = (request: GetStationsNearbyRequest) =>
           `/v1/bus-stops/near?tmX=${request.xlongitude}&tmY=${request.ylatitude}&radius=${request.radius}`,
         )
       ).data,
+    enabled: !!request.xlongitude || !!request.ylatitude,
     staleTime: Infinity, // TODO: 임시설정, 배포 전 staleTime 변경하기
   });
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from 'msw';
 
 const stations = [
   {
+    stationId: '1',
     arsId: '00001',
     stationName: '경기도인재개발원.연구원.평생교육진흥원.여성가족재단',
     nextStationName: '용산우체국',
@@ -9,6 +10,7 @@ const stations = [
     ylatitude: 126.570667,
   },
   {
+    stationId: '2',
     arsId: '01237',
     stationName: '서울신문사',
     nextStationName: '종로2가사거리',
@@ -16,6 +18,7 @@ const stations = [
     ylatitude: 126.97692061282088,
   },
   {
+    stationId: '3',
     arsId: '01238',
     stationName: '서울광장',
     nextStationName: '을지로입구.로얄호텔',
@@ -23,6 +26,7 @@ const stations = [
     ylatitude: 126.97882248848845,
   },
   {
+    stationId: '4',
     arsId: '00003',
     stationName: '역명4',
     nextStationName: '광화문역',
@@ -30,6 +34,7 @@ const stations = [
     ylatitude: 127.0263723554437,
   },
   {
+    stationId: '5',
     arsId: '00003',
     stationName: '역명5',
     nextStationName: '광화문역',
@@ -37,6 +42,7 @@ const stations = [
     ylatitude: 126.570667,
   },
   {
+    stationId: '6',
     arsId: '00003',
     stationName: '역명6',
     nextStationName: '광화문역',
@@ -44,6 +50,7 @@ const stations = [
     ylatitude: 127.0263723554437,
   },
   {
+    stationId: '7',
     stationName: '역명7',
     nextStationName: '광화문역',
     arsId: '00003',
@@ -51,6 +58,7 @@ const stations = [
     ylatitude: 126.570667,
   },
   {
+    stationId: '8',
     arsId: '00003',
     stationName: '역명8',
     nextStationName: '광화문역',
@@ -58,6 +66,7 @@ const stations = [
     ylatitude: 127.0263723554437,
   },
   {
+    stationId: '9',
     arsId: '00003',
     stationName: '역명9',
     nextStationName: '광화문역',
@@ -65,6 +74,7 @@ const stations = [
     ylatitude: 126.570667,
   },
   {
+    stationId: '10',
     stationName: '역명10',
     nextStationName: '광화문역',
     arsId: '00003',
@@ -72,6 +82,7 @@ const stations = [
     ylatitude: 127.0263723554437,
   },
   {
+    stationId: '11',
     arsId: '00003',
     stationName: '역명11',
     nextStationName: '광화문역',
@@ -79,6 +90,7 @@ const stations = [
     ylatitude: 126.570667,
   },
   {
+    stationId: '12',
     arsId: '00003',
     stationName: '역명12',
     nextStationName: '광화문역',
@@ -86,6 +98,7 @@ const stations = [
     ylatitude: 127.0263723554437,
   },
   {
+    stationId: '13',
     arsId: '00003',
     stationName: '역명13',
     nextStationName: '광화문역',
@@ -93,6 +106,7 @@ const stations = [
     ylatitude: 126.570667,
   },
   {
+    stationId: '14',
     arsId: '00003',
     stationName: '역명14',
     nextStationName: '광화문역',
@@ -100,6 +114,7 @@ const stations = [
     ylatitude: 127.0263723554437,
   },
   {
+    stationId: '15',
     arsId: '00003',
     stationName: '역명15',
     nextStationName: '광화문역',


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

파라미터가 0으로 전달되는 것을 수정했어요.

## 🧑‍💻 PR 세부 내용

useQuery에 enabled를 적용해 x,y좌표가 0인 경우는 api를 호출하지 않도록 했어요.

## 📸 스크린샷
<img width="1379" alt="스크린샷 2024-05-01 01 41 49" src="https://github.com/sydney-choi/transit-watch-front-end/assets/68490447/c361d455-c9de-4ae2-b5f0-a3320e73daba">


## 👩🏻‍💻 to reviewer
