### PR TITLE
fix: 검색후 현위치로 되돌아갈 때 주변 정류장이 표시되지 않는것 수정

### DIFF
--- a/src/components/map/ResettingMapCenter.tsx
+++ b/src/components/map/ResettingMapCenter.tsx
@@ -1,6 +1,7 @@
 import { useMap } from 'react-kakao-maps-sdk';
 import { MapFocusButton } from '@/components/common/buttons/map';
 import { Coordinates } from '@/types/location';
+import { useCoordinatesStore } from '@/stores/useCoordinatesStore';
 
 interface ResettingMapCenterProps {
   position: Coordinates;
@@ -8,6 +9,16 @@ interface ResettingMapCenterProps {
 
 export const ResettingMapCenter = ({ position }: ResettingMapCenterProps) => {
   const map = useMap();
+  const { setCoordinates } = useCoordinatesStore();
+  const { lat, lng } = position;
+
+  const handleOnClick = () => {
+    map.setCenter(new kakao.maps.LatLng(lat, lng));
+    setCoordinates({
+      lng,
+      lat,
+    });
+  };
 
   return (
     <MapFocusButton
@@ -25,7 +36,7 @@ export const ResettingMapCenter = ({ position }: ResettingMapCenterProps) => {
         backgroundColor: 'rgba(255, 255, 255, 0.95)',
         boxShadow: '0 2px 1px 0 rgba(0,0,0,0.1), 0 0 3px 0 rgba(0,0,0,0.32)',
       }}
-      onClick={() => map.setCenter(new kakao.maps.LatLng(position.lat, position.lng))}
+      onClick={handleOnClick}
     />
   );
 };


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

검색후 현위치로 되돌아갈 때 주변 정류장이 표시되지 않는것을 수정했어요

## 🧑‍💻 PR 세부 내용

현위치 버튼을 클릭했을 때 초기 좌표가 지도에 표시되도록 수정했어요

## 📸 스크린샷
<img src="https://github.com/sydney-choi/transit-watch-front-end/assets/68490447/3c35514b-0438-47ad-918f-77b1bad7968d">

## 👩🏻‍💻 to reviewer
